### PR TITLE
feat: add fallback component in case name is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ import Icon from "react-native-remix-icon";
 ```
 
 ```javascript
-<Icon name="home-fill" size="48" color="red">
+<Icon name="home-fill" size="48" color="red" fallback={null}>
 ```
 
 ### Props
@@ -47,6 +47,7 @@ import Icon from "react-native-remix-icon";
 | name  | `remixicon-fill` | Name of the icon. Explore the [remixicon](https://remixicon.com) library for all valid icon names |
 | size  | `24`             | Size of the icon                                                                                  |
 | color | `black`          | Color of the icon                                                                                 |
+| fallback | `<Text>Invalid Icon Name</Text>` | Fallback component when invalid name is provided. `null` value will not display anything |
 
 ### Version Alignment
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@ declare interface RemixIconProps {
   name: IconName;
   size?: number | string;
   color?: string;
+  fallback?: JSX.Element | null;
   [key: string]: any;
 }
 declare const RemixIcon: React.FC<RemixIconProps>;

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,9 @@ const RemixIcon = ({
   size = 24,
   ...props
 }) => {
+  if (!name) {
+    return fallback === undefined ? (<Text>Invalid Icon Name</Text>) : fallback;
+  }
   // The icon name from remixicon.com UI starts with "ri-", so we need to remove this prefix if present.
   name = name.startsWith("ri-") ? name.substring(3) : name;
 
@@ -44,9 +47,9 @@ const RemixIcon = ({
 
   return Component ? (
     <Component {...props} fill={color || "black"} width={size} height={size} />
-  ) : (
-    <Text>Invalid Icon Name</Text>
-  );
+  ) :
+    fallback === undefined ? (<Text>Invalid Icon Name</Text>) : fallback
+  ;
 };
 
 export default RemixIcon;


### PR DESCRIPTION
This PR allows to add a fallback property in case invalid icon name is provided.

In my case, icon name comes from server, I don't want the text to be displayed in case of invalid data.

I also fix the case where name is null (causes a crash)